### PR TITLE
store configs to firebase + allow sharing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "gcloudConsole",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "~1.4.0",
+    "angular": "~1.4.7",
     "angular-animate": "~1.4.0",
     "angular-aria": "~1.4.4",
     "angular-google-gapi": "~0.1.3",
@@ -10,6 +10,7 @@
     "angular-material-data-table": "~0.8.11",
     "angular-sanitize": "~1.4.0",
     "angular-ui-router": "~0.2.15",
+    "firebase": "~2.3.1",
     "jquery": "~2.1.4",
     "oclazyload": "~1.0.5",
     "system.js": "~0.19.0"

--- a/src/app/components/configuration/configuration.service.js
+++ b/src/app/components/configuration/configuration.service.js
@@ -1,0 +1,58 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('gcloudConsole')
+    .service('configuration', Configuration);
+
+  function Configuration($q, GData, firebase) {
+    this.userId = GData.getUser().id;
+    this.$q = $q;
+
+    var url = 'https://phoenix-storage.firebaseio.com/configurations';
+    this.getRef = firebase.getRef(url);
+  }
+
+  Configuration.prototype.getByName = function(name) {
+    var deferred = this.$q.defer();
+
+    this.getRef.then(function(configRef) {
+      configRef.child(name).once('value', function(snap) {
+        var configuration = snap.val();
+
+        if (!configuration) {
+          deferred.reject(new Error('Configuration not found.'));
+          return;
+        }
+
+        deferred.resolve(configuration);
+      });
+    });
+
+    return deferred.promise;
+  };
+
+  Configuration.prototype.setByName = function(name, plugins) {
+    var deferred = this.$q.defer();
+
+    var data = {
+      lastModified: new Date().toJSON(),
+      creator: this.userId,
+      plugins: plugins
+    };
+
+    this.getRef.then(function(configRef) {
+      configRef.child(name).set(data, function(err) {
+        if (err) {
+          deferred.reject(err);
+          return;
+        }
+
+        deferred.resolve();
+      });
+    });
+
+    return deferred.promise;
+  };
+
+}());

--- a/src/app/components/firebase/firebase.service.js
+++ b/src/app/components/firebase/firebase.service.js
@@ -1,0 +1,40 @@
+/* global Firebase:true */
+(function() {
+  'use strict';
+
+  angular
+    .module('gcloudConsole')
+    .service('firebase', FirebaseWrapper);
+
+  function FirebaseWrapper($q, GAuth) {
+    this.$q = $q;
+    this.GAuth = GAuth;
+  }
+
+  FirebaseWrapper.prototype.getRef = function(url) {
+    var ref = new Firebase(url);
+
+    var deferred = this.$q.defer();
+
+    if (ref.getAuth()) {
+      deferred.resolve(ref);
+      return deferred.promise;
+    }
+
+    this.GAuth.getToken().then(function(token) {
+      var accessToken = token.access_token;
+
+      ref.authWithOAuthToken('google', accessToken, function(err) {
+        if (err) {
+          deferred.reject(err);
+          return;
+        }
+
+        deferred.resolve(ref);
+      });
+    });
+
+    return deferred.promise;
+  };
+
+}());

--- a/src/app/index.run.js
+++ b/src/app/index.run.js
@@ -11,7 +11,7 @@
     GAuth.setScope(CLOUD_SCOPE);
 
     $rootScope.$on('$stateChangeError', function() {
-      console.log(arguments);
+      console.error(arguments);
     });
 
     $rootScope.$on('$locationChangeSuccess', function(e) {

--- a/src/app/project/project-share-configuration-dialog.html
+++ b/src/app/project/project-share-configuration-dialog.html
@@ -1,0 +1,25 @@
+<md-dialog aria-label="Share configuration dialog" flex="33">
+  <md-dialog-content>
+    <h2>Share Configuration</h2>
+    <p>
+      Sharing your configuration allows others to use the same dashboard you've created within their own projects.
+    </p>
+    <p ng-if="dialog.creating">
+      <small>
+        <em>Note: Names must not contain spaces.</em>
+      </small>
+    </p>
+    <p ng-if="!dialog.creating">
+      Your configuration is now available from this URL: <a ng-href="{{dialog.url}}">{{dialog.url}}</a>
+    </p>
+    <md-input-container ng-if="dialog.creating">
+      <label>Name</label>
+      <input type="text" ng-model="dialog.name" pattern="\S+" required>
+    </md-input-container>
+  </md-dialog-content>
+  <div class="md-actions">
+    <md-button class="md-raised md-accent" ng-if="dialog.creating" ng-click="dialog.share()" ng-disabled="!dialog.name">Share</md-button>
+    <md-button ng-if="dialog.creating" ng-click="dialog.close()">Cancel</md-button>
+    <md-button ng-if="!dialog.creating" ng-click="dialog.close()">Ok</md-button>
+  </div>
+</md-dialog>

--- a/src/app/project/project.controller.js
+++ b/src/app/project/project.controller.js
@@ -5,9 +5,45 @@
     .module('gcloudConsole')
     .controller('ProjectCtrl', ProjectCtrl);
 
-  function ProjectCtrl($project) {
+  function ProjectCtrl($project, $mdDialog) {
     var project = this;
 
+    project.shareConfiguration = shareConfiguration;
+
     project.plugins = $project.plugins;
+
+    function shareConfiguration($event) {
+      $mdDialog.show({
+        parent: angular.element(document.body),
+        targetEvent: $event,
+        templateUrl: 'app/project/project-share-configuration-dialog.html',
+        controller: DialogCtrl,
+        controllerAs: 'dialog',
+        bindToController: true
+      });
+    }
+
+    function DialogCtrl() {
+      var dialog = this;
+
+      dialog.creating = true;
+      dialog.name = 'my-config-name';
+
+      dialog.share = share;
+      dialog.close = closeDialog;
+
+      function share() {
+        return $project.shareConfiguration(dialog.name).then(showUrl);
+      }
+
+      function showUrl() {
+        dialog.creating = false;
+        dialog.url = 'http://' + window.location.host + window.location.pathname + '#/projects/import/' + dialog.name;
+      }
+
+      function closeDialog() {
+        $mdDialog.hide();
+      }
+    }
   }
 }());

--- a/src/app/project/project.html
+++ b/src/app/project/project.html
@@ -21,6 +21,12 @@
         Add plugins
       </sidenav-link>
     </md-list-item>
+    <md-list-item class="project-nav-item">
+      <sidenav-link ng-click="project.shareConfiguration()">
+        <md-icon>share</md-icon>
+        Share configuration
+      </sidenav-link>
+    </md-list-item>
   </md-list>
 </sidenav>
 

--- a/src/app/project/project.service.js
+++ b/src/app/project/project.service.js
@@ -6,7 +6,7 @@
     .factory('projectservice', projectservice);
 
   /** @ngInject */
-  function projectservice($q, $interpolate, $http, System, $ocLazyLoad, projectCache, projectStorage) {
+  function projectservice($q, $interpolate, $http, System, $ocLazyLoad, projectCache, projectStorage, configuration) {
     var getConfigUrl = $interpolate('https://raw.githubusercontent.com/{{repository}}/{{version}}/package.json');
     var getFileUrl = $interpolate('github:{{repository}}@{{version}}/{{file}}');
 
@@ -20,7 +20,7 @@
 
       this.storage = projectStorage({
         projectId: this.id,
-        driver: 'localStorage'
+        driver: 'firebase'
       });
 
       return this.storage.getItem('plugins')
@@ -85,6 +85,18 @@
 
           return $q.all(modules);
         });
+    };
+
+    Project.prototype.importPlugins = function(plugins) {
+      var self = this;
+
+      this.storage.setItem('plugins', plugins).then(function() {
+        self.load();
+      });
+    };
+
+    Project.prototype.shareConfiguration = function(name) {
+      return configuration.setByName(name, angular.copy(this.plugins));
     };
 
     function load(projectId) {

--- a/src/app/projects/configuration-preview.html
+++ b/src/app/projects/configuration-preview.html
@@ -1,0 +1,27 @@
+<md-dialog aria-label="Import configuration dialog">
+  <md-dialog-content>
+
+    <h2>Import Configuration</h2>
+    <p>
+      Select a project from the list below to apply this configuration.
+    </p>
+    <p>
+      <strong>This will overwrite your previous configuration.</strong>
+    </p>
+
+    <md-menu layout="column" class="navbar-project-selector">
+      <md-button ng-click="$mdOpenMenu($event)">
+        Select a project
+        <md-icon class="material-icons">arrow_drop_down</md-icon>
+      </md-button>
+      <md-menu-content width="3">
+        <md-menu-item ng-repeat="option in dialog.projects">
+          <md-button ng-click="dialog.overwriteProjectConfig(option.projectId)">
+            {{option.name}}
+          </md-button>
+        </md-menu-item>
+      </md-menu-content>
+    </md-menu>
+
+  </md-dialog-content>
+</md-dialog>

--- a/src/app/projects/projects.route.js
+++ b/src/app/projects/projects.route.js
@@ -3,7 +3,8 @@
 
   angular
     .module('gcloudConsole')
-    .config(routeConfig);
+    .config(routeConfig)
+    .controller('ImportCtrl', ImportCtrl);
 
   /** @ngInject */
   function routeConfig($stateProvider) {
@@ -14,12 +15,62 @@
         controller: 'ProjectsCtrl',
         controllerAs: 'projects',
         resolve: { projectList: getProjects }
+      })
+      .state('projects.import', {
+        url: '/import/:configurationName',
+        controller: 'ImportCtrl',
+        controllerAs: 'configImport',
+        resolve: { configuration: getConfiguration }
       });
   }
 
   /** @ngInject */
   function getProjects(resource) {
     return resource.getProjectList();
+  }
+
+  /** @ngInject */
+  function getConfiguration($stateParams, configuration) {
+    var configurationName = $stateParams.configurationName;
+    return configuration.getByName(configurationName);
+  }
+
+  /** @ngInject */
+  function ImportCtrl($state, projectservice, projectList, configuration, $mdDialog) {
+    var configImport = this;
+
+    configImport.configuration = configuration;
+
+    if (!configuration.plugins) {
+      // @todo this is an mpty configuration. We shouldn't let the user do
+      // anything with this.
+    }
+
+    $mdDialog.show({
+      parent: angular.element(document.body),
+      templateUrl: 'app/projects/configuration-preview.html',
+      controller: DialogCtrl,
+      controllerAs: 'dialog',
+      bindToController: true
+    });
+
+    function DialogCtrl() {
+      var dialog = this;
+
+      dialog.projects = projectList;
+      dialog.overwriteProjectConfig = overwriteProjectConfig;
+
+      function overwriteProjectConfig(projectId) {
+        projectservice.load(projectId)
+          .then(function(project) {
+            return project.importPlugins(configuration.plugins);
+          })
+          .then(function() {
+            $mdDialog.hide();
+            $state.go('project', { projectId: projectId });
+          });
+      }
+    }
   }
 
 })();


### PR DESCRIPTION
Fixes #33
Fixes #34

#### To Dos

  - [ ] Figure out how to present error messages
  - [ ] Get a review of how I'm using promises
  - [ ] Get a review of architecture - did files go in the right place?
  - [ ] Show if a configuration name is taken onkeyup

This implements some firebase persistence, changing the default storage driver to the new "FirebaseDriver".

There are also two services created:

- `firebase` - Has one method, `getRef`, that returns a promise that returns an authenticated ref. Auth is done with the same token we already have from the user being logged into the console with their Google account.
- `configuration` - Easily access a global configuration.

What's a global configuration? For a better understanding of that, let's look at the schema stored in Firebase.

<img width="268" alt="screen shot 2015-10-09 at 3 48 30 pm" src="https://cloud.githubusercontent.com/assets/723048/10403925/394b32ec-6e9d-11e5-8404-d6013921c934.png">

- `configurations` - stores a list of plug-ins and their configuration using a unique name.
- `projects` - stores a list of projects.

Let's open up `configurations`:
<img width="546" alt="screen shot 2015-10-09 at 3 49 46 pm" src="https://cloud.githubusercontent.com/assets/723048/10403947/66241bf8-6e9d-11e5-92e9-1017c93feee4.png">

- `creator` - Used for firebase security rules. Anyone can create a configuration, but only the original creator can make modifications to it.
- `lastModified` - In case we ever find that useful.
- `plugins` - This is a clone of the plugin configuration that is currently persisted in localStorage. It's likely going to change as we go, so we don't need to dig into the specifics of that object here. Whatever changes we make will automatically go here.

Now, `projects`:
<img width="618" alt="screen shot 2015-10-09 at 3 52 43 pm" src="https://cloud.githubusercontent.com/assets/723048/10404007/cd803868-6e9d-11e5-9f4a-a5b0b0c9e160.png">

- `lastModified` - Again, in case we need this some day.
- `plugins` - Exactly as described above.

### How this all comes together

Anytime a user makes changes to their settings, it is persisted to Firebase, keyed by the project they're making changes for.

There is a new "Share your configuration" button. This brings up a dialog that lets the user give it a name. After doing so, it returns a URL that will load the config, something like: http://stephenplusplus.github.io/phoenix/#/projects/import/the-name-you-chose

When another user goes to that URL, they get a prompt to select the project they want to apply those settings to. After they click "Ok", it redirects them to their project, where **any settings they previously had have now been replaced**.

This is a work in progress, so that last part about replacing everything won't be permanent. Instead, I think we want to go the "cards" route brought up in #29. That way, when a user hits an import URL and selects a project, it doesn't affect their old settings at all, or worry about trying to merge them. It will just create a new "card" by the same name of the configuration (e.g. "easy-storage-ui") under their project, and when they visit it, they'll be able to tweak the plug-ins to their needs without affecting anything else.

This would require some changes in Firebase and the site, so @callmehiphop, we should sync up sometime soon to decide how to proceed.

### For now, **HERE'S A PREVIEW: http://stephenplusplus.github.io/phoenix**
