### PR TITLE
Plugin config

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,6 +11,9 @@
   "jasmine": true,
   "globals": {
     "angular": false,
+    "$": false,
+    "jQuery": false,
+    "_": false,
     "inject": false,
     "module": false,
     "console": false

--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,10 @@
     "angular-sanitize": "~1.4.0",
     "angular-ui-router": "~0.2.15",
     "jquery": "~2.1.4",
+    "lodash": "~3.10.1",
     "oclazyload": "~1.0.5",
-    "system.js": "~0.19.0"
+    "system.js": "~0.19.0",
+    "speakingurl": "~7.0.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.0"

--- a/src/app/components/sidenav/sidenav-link.directive.js
+++ b/src/app/components/sidenav/sidenav-link.directive.js
@@ -19,7 +19,11 @@
 
   // what a terrible name!
   function sidenavLinkLink(scope, elem, attrs, sidenavCtrl) {
-    elem.on('click', function() {
+    elem.on('click', function(e) {
+      if (elem.hasClass('sidenav-link-active')) {
+        e.preventDefault();
+      }
+
       sidenavCtrl.close();
     });
   }

--- a/src/app/components/sidenav/sidenav-link.html
+++ b/src/app/components/sidenav/sidenav-link.html
@@ -1,1 +1,1 @@
-<a class="md-list-item-inner" flex ng-transclude></a>
+<a class="md-list-item-inner" ui-sref-active="sidenav-link-active" flex ng-transclude></a>

--- a/src/app/dashboard/dashboard.controller.js
+++ b/src/app/dashboard/dashboard.controller.js
@@ -6,7 +6,84 @@
     .controller('DashboardCtrl', DashboardCtrl);
 
   /** @ngInject */
-  function DashboardCtrl($scope, $dashboard) {
+  function DashboardCtrl($scope, $dashboard, $mdToast, $mdDialog) {
+    var dashboard = this;
+
     $scope.$dashboard = $dashboard;
+
+    dashboard.configure = configure;
+    dashboard.clone = clone;
+    dashboard.remove = remove;
+
+    function configure(plugin, isUpdate) {
+      var copy = angular.copy(plugin);
+
+      if (!isUpdate) {
+        copy.title = getUniqueName(copy.title);
+      }
+
+      return $mdDialog.show({
+        controller: PluginConfigCtrl,
+        controllerAs: 'vm',
+        bindToController: true,
+        templateUrl: 'app/dashboard/plugin-config.html',
+        locals: { plugin: copy }
+      });
+    }
+
+    function PluginConfigCtrl() {
+      var vm = this;
+      var pluginTitle = vm.plugin.title;
+
+      vm.close = $mdDialog.hide;
+      vm.save = save;
+
+      function save() {
+        return $dashboard
+          .updatePlugin(pluginTitle, vm.plugin)
+          .then(vm.close);
+      }
+    }
+
+    function clone(plugin) {
+      return configure(plugin, false);
+    }
+
+    function getUniqueName(name) {
+      if (!$dashboard.getPluginByTitle(name)) {
+        return name;
+      }
+
+      var i = 0;
+      var title;
+
+      while (++i) {
+        title = name + ' ' + i;
+
+        if (!$dashboard.getPluginByTitle(title)) {
+          return title;
+        }
+      }
+    }
+
+    function remove(plugin) {
+      return $dashboard
+        .removePlugin(plugin)
+        .then(showUndoToast)
+        .then(function(action) {
+          if (action === 'ok') {
+            return $dashboard.addPlugin(plugin);
+          }
+        });
+    }
+
+    function showUndoToast() {
+      var toast = $mdToast.simple();
+
+      toast.content('Plugin removed');
+      toast.action('undo');
+
+      return $mdToast.show(toast);
+    }
   }
 }());

--- a/src/app/dashboard/dashboard.html
+++ b/src/app/dashboard/dashboard.html
@@ -1,20 +1,44 @@
 <!-- dashboard nav -->
 <sidenav class="dashboard-nav">
-  <md-list ng-if="$dashboard.plugins.length">
-    <md-list-item class="dashboard-nav-item dashboard-nav-item-header">
+  <md-list>
+    <md-list-item class="dashboard-nav-item">
       <div class="md-list-item-inner">
-        <md-icon>extension</md-icon>
-        <span flex>Plugins</span>
+        {{$dashboard.id}}
       </div>
     </md-list-item>
-    <md-list-item ng-repeat="plugin in $dashboard.plugins track by $index" class="dashboard-nav-item">
+    <md-divider></md-divider>
+    <md-list-item ng-repeat="plugin in $dashboard.plugins | orderBy:'title' track by plugin.title" class="dashboard-nav-item md-with-secondary">
       <sidenav-link ui-sref="plugin({ pluginId: plugin.id })">
-        {{::plugin.title}}
+        <md-icon>extension</md-icon>
+        {{plugin.title}}
       </sidenav-link>
+      <md-menu class="plugin-menu">
+        <md-button class="md-icon-button md-secondary-container" ng-click="$mdOpenMenu($event)">
+          <md-icon>more_vert</md-icon>
+        </md-button>
+        <md-menu-content width="3">
+          <md-menu-item ng-click="dashboard.configure(plugin, true)">
+            <md-button>
+              <md-icon>settings</md-icon>
+              Settings
+            </md-button>
+          </md-menu-item>
+          <md-menu-item>
+            <md-button ng-click="dashboard.clone(plugin)">
+              <md-icon>content_copy</md-icon>
+              Clone
+            </md-button>
+          </md-menu-item>
+          <md-divider></md-divider>
+          <md-menu-item>
+            <md-button ng-click="dashboard.remove(plugin)">
+              <md-icon>delete</md-icon>
+              Delete
+            </md-button>
+          </md-menu-item>
+        </md-menu-content>
+      </md-menu>
     </md-list-item>
-  </md-list>
-  <md-divider ng-if="$dashboard.plugins.length"></md-divider>
-  <md-list>
     <md-list-item class="dashboard-nav-item">
       <sidenav-link ui-sref="plugins">
         <md-icon>add</md-icon>

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -19,20 +19,21 @@
   color: rgba(0,0,0,0.54);
 }
 
-.dashboard-nav-item-header ~ .dashboard-nav-item .md-list-item-inner {
-  padding-left: 32px;
-}
-
 .dashboard-nav a {
   color: rgba(0, 0, 0, 0.87);
   text-decoration: none;
   transition: background-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 
-  &:hover {
+  &:hover,
+  &.sidenav-link-active {
     background-color: rgba(158, 158, 158, 0.2);
   }
 }
 
 .dashboard-nav md-icon {
   margin-left: 0;
+}
+
+.plugin-menu > .md-button {
+  right: 0;
 }

--- a/src/app/dashboard/dashboard.service.js
+++ b/src/app/dashboard/dashboard.service.js
@@ -1,3 +1,4 @@
+/* global getSlug:true */
 (function() {
   /* jshint newcap:false */
   'use strict';
@@ -20,23 +21,18 @@
       this.plugins = plugins || [];
     }
 
-    $Dashboard.prototype._getPluginById = function(pluginId) {
-      var l = this.plugins.length;
-      var i = 0;
+    $Dashboard.prototype.getPluginById = function(pluginId) {
+      return _.findWhere(this.plugins, { id: pluginId });
+    };
 
-      for (; i < l; i++) {
-        if (this.plugins[i].id === pluginId) {
-          return this.plugins[i];
-        }
-      }
-
-      return null;
+    $Dashboard.prototype.getPluginByTitle = function(title) {
+      return _.findWhere(this.plugins, { title: title });
     };
 
     $Dashboard.prototype.loadPlugin = function(pluginId) {
-      var plugin = this._getPluginById(pluginId);
+      var plugin = this.getPluginById(pluginId);
       var pluginUrl;
-console.log(plugin);
+
       if (!plugin) {
         return $q.reject('Unknown plugin "' + pluginId + '"');
       }
@@ -71,7 +67,7 @@ console.log(plugin);
     };
 
     $Dashboard.prototype.getPlugin = function(pluginId) {
-      var plugin = this._getPluginById(pluginId);
+      var plugin = this.getPluginById(pluginId);
 
       if (!plugin) {
         return $q.reject('Unknown plugin "' + pluginId + '"');
@@ -80,14 +76,31 @@ console.log(plugin);
       return $q.resolve(new $Plugin(plugin));
     };
 
-    $Dashboard.prototype.addPlugin = function(plugin) {
-      this.plugins.push(plugin);
+    $Dashboard.prototype.save = function() {
       return storage.setItem(this.id, this.plugins);
+    };
+
+    $Dashboard.prototype.addPlugin = function(plugin) {
+      plugin.id = getSlug(plugin.title);
+      this.plugins.push(plugin);
+
+      return this.save();
+    };
+
+    $Dashboard.prototype.updatePlugin = function(title, updatedPlugin) {
+      var plugin = this.getPluginByTitle(title);
+
+      if (plugin) {
+        this.removePlugin(plugin);
+      }
+
+      return this.addPlugin(updatedPlugin);
     };
 
     $Dashboard.prototype.removePlugin = function(plugin) {
       this.plugins.splice(this.plugins.indexOf(plugin), 1);
-      return storage.setItem(this.id, this.plugins);
+
+      return this.save();
     };
 
     return $Dashboard;

--- a/src/app/dashboard/plugin-config.html
+++ b/src/app/dashboard/plugin-config.html
@@ -1,0 +1,17 @@
+<md-dialog>
+  <md-dialog-content>
+    <!-- {{vm.plugin.title}} -->
+    <form name="pluginForm">
+      <div class="md-layout-row">
+        <md-input-container>
+          <label>Name</label>
+          <input type="text" ng-model="vm.plugin.title">
+        </md-input-container>
+      </div>
+    </form>
+  </md-dialog-content>
+  <div class="md-actions">
+    <md-button ng-click="vm.save()">Save</md-button>
+    <md-button ng-click="vm.close()">Cancel</md-button>
+  </div>
+</md-dialog>

--- a/src/app/plugin/plugin.controller.js
+++ b/src/app/plugin/plugin.controller.js
@@ -6,7 +6,8 @@
     .controller('PluginCtrl', PluginCtrl);
 
   /** @ngInject */
-  function PluginCtrl($scope, $plugin) {
+  function PluginCtrl($scope, $plugin, $state) {
     $scope.$plugin = $plugin;
+    $state.go($plugin.state);
   }
 }());

--- a/src/app/plugin/plugin.route.js
+++ b/src/app/plugin/plugin.route.js
@@ -1,4 +1,3 @@
-/* global setTimeout:true */
 (function() {
   'use strict';
 
@@ -22,11 +21,27 @@
   function getPlugin($dashboard, $state, $stateParams) {
     var pluginId = $stateParams.pluginId;
 
+    function getDefaultState() {
+      return { state: pluginId };
+    }
+
+    function getPluginFiles($plugin) {
+      var hasState = !!$state.get(pluginId);
+
+      if (hasState) {
+        return $plugin;
+      }
+
+      return $dashboard
+        .loadPlugin($plugin.state)
+        .then(function() {
+          return $plugin;
+        });
+    }
+
     return $dashboard
-      .loadPlugin(pluginId)
-      .then(function() {
-        setTimeout(angular.bind($state, $state.go), 0, pluginId);
-        return $dashboard.getPlugin(pluginId);
-      });
+      .getPlugin(pluginId)
+      .then(null, getDefaultState)
+      .then(getPluginFiles);
   }
 }());

--- a/src/app/plugins/plugins.controller.js
+++ b/src/app/plugins/plugins.controller.js
@@ -6,19 +6,9 @@
     .controller('PluginsCtrl', PluginsCtrl);
 
   /** @ngInject */
-  function PluginsCtrl(pluginList, $dashboard) {
+  function PluginsCtrl(pluginList) {
     var plugins = this;
 
     plugins.list = pluginList;
-    plugins.toggle = toggle;
-
-    function toggle(plugin) {
-      if (plugin.isEnabled) {
-        $dashboard.addPlugin(plugin);
-        return;
-      }
-
-      $dashboard.removePlugin(plugin);
-    }
   }
 }());

--- a/src/app/plugins/plugins.html
+++ b/src/app/plugins/plugins.html
@@ -25,14 +25,17 @@
       <thead>
         <tr>
           <th name="Name" />
-          <th name="Enabled" />
+          <th name="" />
         </tr>
       </thead>
       <tbody>
         <tr ng-repeat="plugin in plugins.list | filter: plugins.filter">
           <td>{{plugin.title}}</td>
           <td>
-            <md-switch ng-model="plugin.isEnabled" aria-label="Enable plugin" ng-change="plugins.toggle(plugin)"></md-switch>
+            <md-button class="md-icon-button" ng-click="dashboard.configure(plugin, false)">
+              <md-tooltip>Add plugin</md-tooltip>
+              <md-icon>add</md-icon>
+            </md-button>
           </td>
         </tr>
       </tbody>

--- a/src/app/plugins/plugins.route.js
+++ b/src/app/plugins/plugins.route.js
@@ -19,16 +19,10 @@
   }
 
   /** @ngInject */
-  function getPluginList($http, $dashboard, projectCache) {
+  function getPluginList($http, projectCache) {
     return $http.get('plugins.json', { cache: projectCache })
       .then(function(response) {
-        var plugins = response.data;
-
-        plugins.forEach(function(plugin) {
-          plugin.isEnabled = !!$dashboard._getPluginById(plugin.id);
-        });
-
-        return plugins;
+        return response.data;
       });
   }
 }());

--- a/src/app/projects/projects.service.js
+++ b/src/app/projects/projects.service.js
@@ -16,21 +16,8 @@
       this.list = list;
     }
 
-    $Projects.prototype._getByProjectId = function(projectId) {
-      var length = this.list.length;
-      var i = 0;
-
-      for (; i < length; i++) {
-        if (this.list[i].projectId === projectId) {
-          return this.list[i];
-        }
-      }
-
-      return null;
-    };
-
     $Projects.prototype.getProject = function(projectId) {
-      var project = this._getByProjectId(projectId);
+      var project = _.findWhere(this.list, { projectId: projectId });
 
       if (!project) {
         return $q.reject('Unknown project "' + projectId + '"');

--- a/src/plugins.json
+++ b/src/plugins.json
@@ -1,6 +1,6 @@
 [{
   "title": "Storage Browser",
-  "id": "storage-browser",
+  "state": "storage-browser",
   "repository": "jgeewax/gcloud-ui-storage-browser",
   "version": "v0.0.2"
 }]


### PR DESCRIPTION
closes #30 
closes #31
closes #32  

Per conversations with @stephenplusplus, we decided to move deleting/updating logic into the dashboard menu. The `Add plugins` menu will now allow you to add a single plugin an infinite number of times.

This is not a backwards compatible change, so you'll probably need to uninstall all your plugins and start over.

[demo](http://callmehiphop.github.io/phoenix/)