### PR TITLE
implement dashboards

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "angular-animate": "~1.4.0",
     "angular-aria": "~1.4.4",
     "angular-google-gapi": "~0.1.3",
-    "angular-material": "~0.11.0",
+    "angular-material": "~1.0.0",
     "angular-material-data-table": "~0.8.11",
     "angular-sanitize": "~1.4.0",
     "angular-ui-router": "~0.2.15",
@@ -23,6 +23,6 @@
   "resolutions": {
     "jquery": "~2.1.4",
     "angular": "~1.4.0",
-    "angular-material": "~0.11.0"
+    "angular-material": "~1.0.0"
   }
 }

--- a/src/app/components/if-available/ifAvailable.directive.js
+++ b/src/app/components/if-available/ifAvailable.directive.js
@@ -1,0 +1,30 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('gcloudConsole')
+    .directive('ifAvailable', ifAvailable);
+
+  /** @ngInject */
+  function ifAvailable($q, firebaseDriver) {
+    return {
+      restrict: 'A',
+      require: 'ngModel',
+      scope: {
+        getRef: '='
+      },
+      link: function(scope, element, attrs, ctrl) {
+        ctrl.$asyncValidators.ifAvailable = function(value) {
+          return firebaseDriver.exists(scope.getRef(value))
+            .then(function(exists) {
+              if (exists) {
+                return $q.reject();
+              } else {
+                return $q.resolve();
+              }
+            });
+        };
+      }
+    };
+  }
+}());

--- a/src/app/components/navbar/navbar.directive.js
+++ b/src/app/components/navbar/navbar.directive.js
@@ -23,12 +23,10 @@
 
   /** @ngInject */
   function NavbarCtrl($state, $scope, Navbar, GAuth) {
-    var DEFAULT_OPTION = { name: 'Select a project' };
-
     var navbar = this;
     var projects = navbar.projects;
 
-    navbar.selectedProject = DEFAULT_OPTION;
+    navbar.selectedProject = null;
     navbar.logout = logout;
     navbar.openSideNav = Navbar.openSideNav;
     navbar.hasSideNav = hasSideNav;
@@ -40,7 +38,7 @@
     }
 
     function setSelectedProject(projectId) {
-      navbar.selectedProject = projects[projectId] || DEFAULT_OPTION;
+      navbar.selectedProject = projects[projectId];
     }
 
     function logout() {

--- a/src/app/components/navbar/navbar.html
+++ b/src/app/components/navbar/navbar.html
@@ -5,7 +5,7 @@
   <a ui-sref="projects" title="Developer Console Projects">
     <img class="navbar-logo" src="assets/images/logo-color.svg" alt="gcloud">
   </a>
-  <md-menu layout="column" class="navbar-project-selector">
+  <md-menu layout="column" class="navbar-project-selector" ng-if="navbar.selectedProject">
     <md-button ng-click="$mdOpenMenu($event)">
       {{navbar.selectedProject.name}}
       <md-icon class="material-icons">arrow_drop_down</md-icon>

--- a/src/app/components/text-selected/text-selected.directive.js
+++ b/src/app/components/text-selected/text-selected.directive.js
@@ -1,0 +1,23 @@
+/* global setTimeout:true */
+(function() {
+  'use strict';
+
+  angular
+    .module('gcloudConsole')
+    .directive('textSelected', textSelected);
+
+  /** @ngInject */
+  function textSelected() {
+    return {
+      restrict: 'A',
+      priority: 1,
+      link: textSelectedLink
+    };
+  }
+
+  function textSelectedLink(scope, elem) {
+    var el = elem[0];
+
+    setTimeout(angular.bind(el, el.select), 500);
+  }
+}());

--- a/src/app/dashboard/dashboard.html
+++ b/src/app/dashboard/dashboard.html
@@ -2,18 +2,32 @@
 <sidenav class="dashboard-nav">
   <md-list>
     <md-list-item class="dashboard-nav-item">
-      <div class="md-list-item-inner">
-        {{$dashboard.id}}
-      </div>
+      <md-input-container class="dashboard-picker md-list-item-inner" flex>
+        <md-select
+          ng-model="$dashboard.$dataRef.name"
+          placeholder="Select a Dashboard"
+          flex>
+          <md-option
+            ng-repeat="(dashId, dashData) in $project.dashboards.$data"
+            ng-value="dashData.name"
+            ui-sref="dashboard({ dashboardId: dashId })">
+            {{dashData.name}}
+          </md-option>
+        </md-select>
+      </md-input-container>
     </md-list-item>
     <md-divider></md-divider>
-    <md-list-item ng-repeat="(pluginId, plugin) in $dashboard.$dataRef.plugins | orderBy:'title' track by plugin.title" class="dashboard-nav-item md-with-secondary">
+    <md-list-item
+      ng-repeat="(pluginId, plugin) in $dashboard.$dataRef.plugins | orderBy:'title' track by plugin.title"
+      class="dashboard-nav-item md-with-secondary">
       <sidenav-link ui-sref="plugin({ pluginId: pluginId })">
         <md-icon>extension</md-icon>
         {{plugin.title}}
       </sidenav-link>
       <md-menu class="plugin-menu">
-        <md-button class="md-icon-button md-secondary-container" ng-click="$mdOpenMenu($event)">
+        <md-button
+          class="md-icon-button md-secondary-container"
+          ng-click="$mdOpenMenu($event)">
           <md-icon>more_vert</md-icon>
         </md-button>
         <md-menu-content width="3">

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -1,5 +1,6 @@
 .dashboard-nav {
   background-color: rgb(250, 250, 250) !important;
+  margin: 0;
 }
 
 .dashboard-nav-item,
@@ -36,4 +37,12 @@
 
 .plugin-menu > .md-button {
   right: 0;
+}
+
+.dashboard-picker {
+  margin: 0 !important;
+
+  .md-select-value {
+    border-bottom-color: transparent;
+  }
 }

--- a/src/app/dashboard/dashboard.service.js
+++ b/src/app/dashboard/dashboard.service.js
@@ -16,24 +16,30 @@
       this.projectId = projectId;
       this.id = id;
 
-      this.$dataRef = firebaseDriver.getMyDashboard({
+      this.$dataRef = firebaseDriver.getDashboard({
         projectId: projectId,
         dashboardId: id
       });
     }
+
+    $Dashboard.prototype.remove = function() {
+      return this.$dataRef.$remove();
+    };
 
     $Dashboard.prototype.read = function() {
       return this.$dataRef.$loaded();
     };
 
     $Dashboard.prototype.save = function(data) {
-      return this.$dataRef.then(function($ref) {
-        return $ref.$save(data);
-      });
+      return firebaseDriver.save(this.$dataRef, data);
     };
 
     $Dashboard.prototype.getPlugin = function(id) {
       return new $Plugin(this.projectId, this.id, id);
+    };
+
+    $Dashboard.prototype.exists = function() {
+      return firebaseDriver.exists(this.$dataRef);
     };
 
     return $Dashboard;

--- a/src/app/dashboard/plugin-config.html
+++ b/src/app/dashboard/plugin-config.html
@@ -1,9 +1,9 @@
 <md-dialog>
-  <md-dialog-content>
+  <md-dialog-content class="md-padding">
     <!-- {{vm.plugin.title}} -->
     <form name="pluginForm">
       <div class="md-layout-row">
-        <md-input-container>
+        <md-input-container class="md-block">
           <label>Name</label>
           <input type="text" ng-model="vm.plugin.title">
         </md-input-container>

--- a/src/app/index.config.js
+++ b/src/app/index.config.js
@@ -6,7 +6,14 @@
     .config(config);
 
   /** @ngInject */
-  function config($mdThemingProvider) {
+  function config($urlRouterProvider, $mdThemingProvider) {
+    $urlRouterProvider.deferIntercept();
+
+    $urlRouterProvider.otherwise(function($injector) {
+      var GData = $injector.get('GData');
+      return GData.isLogin() ? '/projects' : '/login';
+    });
+
     var consolePalette = $mdThemingProvider.extendPalette('grey', {
       '0': '#9e9e9e',
       '500': '#fafafa'

--- a/src/app/index.route.js
+++ b/src/app/index.route.js
@@ -3,15 +3,12 @@
 
   angular
     .module('gcloudConsole')
-    .config(routeConfig);
+    .run(runBlock);
 
   /** @ngInject */
-  function routeConfig($urlRouterProvider) {
-    $urlRouterProvider.deferIntercept();
-
-    $urlRouterProvider.otherwise(function($injector) {
-      var GData = $injector.get('GData');
-      return GData.isLogin() ? '/projects' : '/login';
+  function runBlock($rootScope) {
+    $rootScope.$on('$stateChangeSuccess', function(e, toState) {
+      $rootScope.ACTIVE_STATE = toState;
     });
   }
 

--- a/src/app/plugin/plugin.service.js
+++ b/src/app/plugin/plugin.service.js
@@ -37,8 +37,7 @@
     };
 
     $Plugin.prototype.save = function(data) {
-      angular.extend(this.$dataRef, data);
-      return this.$dataRef.$save();
+      return firebaseDriver.save(this.$dataRef, data);
     };
 
     $Plugin.prototype.load = function() {

--- a/src/app/project/project.service.js
+++ b/src/app/project/project.service.js
@@ -1,3 +1,4 @@
+/* global getSlug:true */
 (function() {
   /* jshint newcap:false */
   'use strict';
@@ -7,7 +8,7 @@
     .factory('$Project', $projectFactory);
 
   /** @ngInject */
-  function $projectFactory($Dashboard, firebaseDriver) {
+  function $projectFactory($Dashboard, $q, firebaseDriver) {
     function $Project(project) {
       if (!(this instanceof $Project)) {
         return new $Project(project);
@@ -17,9 +18,32 @@
 
       this.id = project.projectId;
       this.dashboards = {
-        $data: firebaseDriver.getMyDashboards(this.id)
+        $data: firebaseDriver.getDashboards(this.id)
       };
     }
+
+    $Project.prototype.createDashboard = function(name, plugins) {
+      var dashboardId = getSlug(name);
+      var $dashboard = this.getDashboard(dashboardId);
+
+      return $dashboard.exists()
+        .then(function(exists) {
+          if (exists) {
+            return $q.reject(new Error('Dashboard already exists'));
+          }
+
+          var options = { name: name };
+
+          if (plugins) {
+            options.plugins = plugins;
+          }
+
+          return $dashboard.save(options);
+        })
+        .then(function() {
+          return $dashboard;
+        });
+    };
 
     $Project.prototype.getDashboard = function(id) {
       return new $Dashboard(this.id, id);

--- a/src/app/projects/add-dashboard-dialog.html
+++ b/src/app/projects/add-dashboard-dialog.html
@@ -1,0 +1,71 @@
+<md-dialog area-label="Add Dashboard" flex="30" class="dashboard-add-dialog">
+  <md-dialog-content>
+    <md-tabs md-dynamic-height md-border-bottom>
+      <md-tab label="Create" md-on-select="dialog.add = dialog.create">
+        <md-content>
+          <form name="createDashboard">
+            <div class="md-padding">
+              <h3 class="md-title">Popular Dashboards</h3>
+              <md-card
+                class="dashboard-card dashboard-card--global"
+                ng-repeat="(dashboardId, dashboardData) in dialog.popularDashboards"
+                ng-click="dialog.selectDashboard(dashboardId, dashboardData)"
+                ng-class="{ 'dashboard-card--selected': dialog.inheritFrom === dashboardId }">
+                <md-card-content>
+                  <h3 class="md-subhead">
+                    {{dashboardData.name}}
+                  </h3>
+                </md-card-content>
+              </md-card>
+            </div>
+
+            <div class="md-padding">
+              <md-input-container class="md-block">
+                <label>Name</label>
+                <input type="text" ng-model="dialog.name" name="name" required if-available get-ref="dialog.getRef">
+                <div ng-messages="createDashboard.name.$error">
+                  <div ng-if="createDashboard.name.$error.ifAvailable" ng-message>This name is already taken.</div>
+                </div>
+              </md-input-container>
+            </div>
+          </form>
+        </md-content>
+      </md-tab>
+
+      <md-tab label="Import" md-on-select="dialog.add = dialog.importDash">
+        <md-content class="md-padding">
+          <form name="importDashboard">
+            <md-input-container class="md-block">
+              <label>Code</label>
+              <input type="text" ng-model="dialog.code" name="code" required>
+              <div ng-messages="importDashboard.code.$error">
+                <div ng-if="importDashboard.code.$error.exists" ng-message>The provided code is invalid.</div>
+              </div>
+            </md-input-container>
+            <div ng-if="dialog.import">
+              <md-input-container class="md-block">
+                <label>Name</label>
+                <input type="text" ng-model="dialog.import.name" name="name" required if-available get-ref="dialog.getRef">
+                <div ng-messages="importDashboard.name.$error">
+                  <div ng-if="importDashboard.name.$error.ifAvailable" ng-message>This name is already taken.</div>
+                </div>
+              </md-input-container>
+            </div>
+            <div ng-if="dialog.import.plugins">
+              <label>Plugins</label>
+              <ul>
+                <li ng-repeat="plugin in dialog.import.plugins">
+                  {{plugin.title}}
+                </li>
+              </ul>
+            </div>
+          </form>
+        </md-content>
+      </md-tab>
+    </md-tabs>
+  </md-dialog-content>
+  <div class="md-actions">
+    <md-button ng-click="dialog.close()">Cancel</md-button>
+    <md-button class="md-raised md-accent" ng-click="dialog.add()">Add</md-button>
+  </div>
+</md-dialog>

--- a/src/app/projects/code-dialog.html
+++ b/src/app/projects/code-dialog.html
@@ -1,0 +1,12 @@
+<md-dialog flex="30">
+  <md-dialog-content class="md-padding">
+    <h2>Share this code</h2>
+    <md-input-container class="md-block">
+      <label>Code</label>
+      <input type="text" ng-model="dialog.code" text-selected readonly>
+    </md-input-container>
+  </md-dialog-content>
+  <div class="md-actions">
+    <md-button ng-click="dialog.close()">Close</md-button>
+  </div>
+</md-dialog>

--- a/src/app/projects/projects.controller.js
+++ b/src/app/projects/projects.controller.js
@@ -1,3 +1,4 @@
+/* global getSlug:true */
 (function() {
   'use strict';
 
@@ -5,7 +6,185 @@
     .module('gcloudConsole')
     .controller('ProjectsCtrl', ProjectsCtrl);
 
-  function ProjectsCtrl($scope, $projects) {
-    $scope.$projects = $projects;
+  /* @ngInject */
+  function ProjectsCtrl($rootScope, $projects, $mdDialog, $mdToast, $firebaseUtils, firebaseDriver) {
+    var projects = this;
+    var userId = firebaseDriver.getUserId();
+
+    projects.map = $projects.projects;
+
+    angular.forEach(projects.map, function(project, projectId) {
+      project.dashboards = getDashboardsForProject(projectId);
+    });
+
+    function getDashboardsForProject(projectId) {
+      var allDashboards = $projects.getProject(projectId).dashboards.$data;
+
+      var dashboardsObj = {
+        others: {},
+        othersCount: 0,
+        self: {},
+        selfCount: 0
+      };
+
+      allDashboards.$watch(function() {
+        var dashboards = $firebaseUtils.toJSON(allDashboards);
+
+        dashboardsObj.others = {};
+        dashboardsObj.othersCount = 0;
+
+        dashboardsObj.self = {};
+        dashboardsObj.selfCount = 0;
+
+        for (var dashboardId in dashboards) {
+          var dashboard = dashboards[dashboardId];
+          if (dashboard.creator === userId) {
+            dashboardsObj.self[dashboardId] = dashboard;
+            dashboardsObj.selfCount++;
+          } else {
+            dashboardsObj.others[dashboardId] = dashboard;
+            dashboardsObj.othersCount++;
+          }
+        }
+      });
+
+      return dashboardsObj;
+    }
+
+    projects.createDashboard = createDashboard;
+    projects.deleteDashboard = deleteDashboard;
+    projects.shareDashboard = shareDashboard;
+
+    function createDashboard(projectId) {
+      var $project = $projects.getProject(projectId);
+
+      $mdDialog.show({
+        parent: angular.element(document.body),
+        templateUrl: 'app/projects/add-dashboard-dialog.html',
+        controller: DialogCtrl,
+        controllerAs: 'dialog',
+        bindToController: true
+      });
+
+      /** @ngInject */
+      function DialogCtrl($state, $scope, $timeout, $q, firebaseDriver) {
+        var dialog = this;
+        var timeoutHandle;
+
+        dialog.name = 'My Custom Dashboard';
+
+        dialog.create = create;
+        dialog.importDash = importDash;
+        dialog.getRef = getRef;
+        dialog.close = closeDialog;
+        dialog.popularDashboards = firebaseDriver.getPopularDashboards();
+        dialog.selectDashboard = selectDashboard;
+
+        $scope.$watch('dialog.code', function(code) {
+          if (!code) {
+            return;
+          }
+
+          $timeout.cancel(timeoutHandle);
+
+          timeoutHandle = $timeout(function() {
+            $projects.getDashboard(code)
+              .read()
+              .then(function(data) {
+                if (!data.name) {
+                  return $q.reject('Dashboard not found');
+                }
+
+                dialog.import = data;
+                $scope.importDashboard.code.$error.exists = false;
+              })
+              .then(null, function() {
+                // eh.. this could be better handled
+                dialog.import = null;
+                $scope.importDashboard.code.$error.exists = true;
+              });
+          }, 1000);
+        });
+
+        function importDash() {
+          return $project.createDashboard(dialog.import.name, dialog.import.plugins)
+            .then(closeDialog, function() {
+              var errorToast = $mdToast.simple()
+                .content('Unable to import Dashboard')
+                .action('Ok');
+
+              return $mdToast.show(errorToast);
+            });
+        }
+
+        function create() {
+          return $project.createDashboard(dialog.name, dialog.plugins)
+            .then(closeDialog, function() {
+              var errorToast = $mdToast.simple()
+                .content('Unable to create Dashboard')
+                .action('Ok');
+
+              return $mdToast.show(errorToast);
+            });
+        }
+
+        function getRef(name) {
+          return $project.getDashboard(getSlug(name)).$dataRef;
+        }
+
+        function closeDialog() {
+          $mdDialog.hide();
+        }
+
+        function selectDashboard(dashboardId, dashboardData) {
+          if (dialog.inheritFrom === dashboardId) {
+            dialog.inheritFrom = null;
+            dialog.plugins = [];
+          } else {
+            dialog.inheritFrom = dashboardId;
+            dialog.plugins = dashboardData.plugins;
+          }
+        }
+      }
+    }
+
+    function deleteDashboard(projectId, dashboardId) {
+      var $project = $projects.getProject(projectId);
+      var $dashboard = $project.getDashboard(dashboardId);
+
+      return $dashboard.remove()
+        .then(function() {
+          return $mdToast.simple().content('Dashboard deleted');
+        }, function() {
+          return $mdToast.simple().content('Unable to delete Dashboard');
+        })
+        .then(function(options) {
+          return $mdToast.show(options.action('ok'));
+        });
+    }
+
+    function shareDashboard(projectId, dashboardId) {
+      var $project = $projects.getProject(projectId);
+      var $dashboard = $project.getDashboard(dashboardId);
+
+      var newDashboardId = dashboardId + '-' + Date.now();
+
+      return $dashboard.read()
+        .then(function(data) {
+          var $globalDashboard = $projects.getDashboard(newDashboardId);
+          return $globalDashboard.save(data);
+        })
+        .then(function() {
+          return $mdDialog.show({
+            templateUrl: 'app/projects/code-dialog.html',
+            controller: function() {
+              this.close = angular.bind($mdDialog, $mdDialog.hide);
+            },
+            controllerAs: 'dialog',
+            locals: { code: newDashboardId },
+            bindToController: true
+          });
+        });
+    }
   }
 }());

--- a/src/app/projects/projects.html
+++ b/src/app/projects/projects.html
@@ -1,5 +1,82 @@
 <section layout="column" flex>
-  <navbar projects="$projects.projects" user="gapi.user"></navbar>
+  <navbar projects="projects.map" user="gapi.user"></navbar>
+  <div ng-if="ACTIVE_STATE.name === 'projects'">
+    <md-tabs class="dashboard-tabs" md-dynamic-height>
+      <md-tab
+        class="dashboard-tab"
+        ng-repeat="(projectId, projectData) in projects.map"
+        label="{{projectData.name}}"
+        md-on-deselect="projects.dashboardListId = null"
+        md-on-select="projects.dashboardListId = projectId">
+
+        <h1
+          class="md-title layout-padding"
+          ng-if="projectData.dashboards.othersCount > 0">
+          Project Dashboards
+        </h1>
+        <div layout="row" layout-sm="column">
+          <md-card
+            class="dashboard-card dashboard-card--not-self"
+            ng-repeat="(dashboardId, dashboardData) in projectData.dashboards.others">
+            <md-card-content ui-sref="dashboard({ projectId: projectId, dashboardId: dashboardId })">
+              <h3 class="md-title">{{dashboardData.name || 'Default Dashboard'}}</h3>
+            </md-card-content>
+            <md-divider></md-divider>
+            <div class="md-actions" layout="row" layout-align="end center">
+              <md-button class="md-icon-button">
+                <md-tooltip>Edit Dashboard</md-tooltip>
+                <md-icon>edit</md-icon>
+              </md-button>
+              <md-button class="md-icon-button" ng-click="projects.shareDashboard(projectId, dashboardId)">
+                <md-tooltip>Share Dashboard</md-tooltip>
+                <md-icon>share</md-icon>
+              </md-button>
+              <md-button class="md-icon-button" ng-click="projects.deleteDashboard(projectId, dashboardId)">
+                <md-tooltip>Delete Dashboard</md-tooltip>
+                <md-icon>delete</md-icon>
+              </md-button>
+            </div>
+          </md-card>
+        </div>
+
+        <h1
+          class="md-title layout-padding"
+          ng-if="projectData.dashboards.selfCount > 0 && projectData.dashboards.othersCount > 0">
+          My Dashboards
+        </h1>
+        <div layout="row" layout-sm="column">
+          <md-card
+            class="dashboard-card"
+            ng-repeat="(dashboardId, dashboardData) in projectData.dashboards.self">
+            <md-card-content ui-sref="dashboard({ projectId: projectId, dashboardId: dashboardId })">
+              <h3 class="md-title">{{dashboardData.name || 'Default Dashboard'}}</h3>
+            </md-card-content>
+            <md-divider></md-divider>
+            <div class="md-actions" layout="row" layout-align="end center">
+              <md-button class="md-icon-button">
+                <md-tooltip>Edit Dashboard</md-tooltip>
+                <md-icon>edit</md-icon>
+              </md-button>
+              <md-button class="md-icon-button" ng-click="projects.shareDashboard(projectId, dashboardId)">
+                <md-tooltip>Share Dashboard</md-tooltip>
+                <md-icon>share</md-icon>
+              </md-button>
+              <md-button class="md-icon-button" ng-click="projects.deleteDashboard(projectId, dashboardId)">
+                <md-tooltip>Delete Dashboard</md-tooltip>
+                <md-icon>delete</md-icon>
+              </md-button>
+            </div>
+          </md-card>
+        </div>
+      </md-tab>
+    </md-tabs>
+    <md-button
+      class="md-fab dashboard-add"
+      ng-if="projects.dashboardListId"
+      ng-click="projects.createDashboard(projects.dashboardListId)">
+      <md-tooltip>Create a new Dashboard</md-tooltip>
+      <md-icon>add</md-icon>
+    </md-button>
+  </div>
   <div ui-view layout="column" flex></div>
 </section>
-

--- a/src/app/projects/projects.scss
+++ b/src/app/projects/projects.scss
@@ -1,0 +1,62 @@
+.dashboard-tabs {
+  z-index: 2;
+
+  md-tabs-wrapper {
+    background-color: rgb(250,250,250);
+    box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
+  }
+
+  md-tab-content {
+    min-height: 5px;
+  }
+}
+
+.dashboard-add-dialog,
+.dashboard-tabs {
+  .md-tab.md-active {
+    color: rgba(0,0,0,0.87);
+  }
+}
+
+.dashboard-card {
+  cursor: pointer;
+  background-color: #00BCD4;
+  color: #fff;
+
+  md-divider {
+    border-top-color: rgba(255, 255, 255, 0.3);
+  }
+
+  md-icon {
+    color: #fff;
+  }
+}
+
+.dashboard-card--not-self {
+  background-color: #607D8B;
+}
+
+.dashboard-add {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+
+  @media (min-width: $md) {
+    bottom: 24px;
+    right: 24px;
+  }
+}
+
+.dashboard-card--global {
+  transition: background-color .25s, color .25s;
+  background-color: #F06292;
+
+  &:focus {
+    outline: 0;
+  }
+}
+
+.dashboard-card--selected {
+  background-color: #FCE4EC;
+  color: rgba(0, 0, 0, 0.87);
+}

--- a/src/app/projects/projects.service.js
+++ b/src/app/projects/projects.service.js
@@ -7,7 +7,7 @@
     .factory('$Projects', $projectsFactory);
 
   /** @ngInject */
-  function $projectsFactory($q, $Project) {
+  function $projectsFactory($q, $Project, $Dashboard) {
     function $Projects(projects) {
       if (!(this instanceof $Projects)) {
         return new $Projects(projects);
@@ -23,6 +23,10 @@
 
     $Projects.prototype.getProject = function(id) {
       return new $Project(this.projects[id]);
+    };
+
+    $Projects.prototype.getDashboard = function(id) {
+      return new $Dashboard(null, id);
     };
 
     return $Projects;


### PR DESCRIPTION
### Demo

http://stephenplusplus.github.io/phoenix/#/projects

<img width="749" alt="screen shot 2015-11-04 at 2 46 14 pm" src="https://cloud.githubusercontent.com/assets/723048/10949824/d910f9c8-8302-11e5-8128-cd5f14e64e99.png">

<img width="839" alt="screen shot 2015-11-05 at 9 57 29 am" src="https://cloud.githubusercontent.com/assets/723048/10971713/a9cfabd6-83a3-11e5-955a-1668eabcdd43.png">

<img width="982" alt="screen shot 2015-11-05 at 11 40 54 am" src="https://cloud.githubusercontent.com/assets/723048/10974890/1da6a63c-83b2-11e5-9d7e-91a5d049ddac.png">
#### To Dos

**Display all dashboards for a project**
- [x] All dashboards created for a project will be visible to any user who has permissions to view that project
- [x] Separate a user's own dashboards from the project's dashboards that they didn't create

**Allow using Popular Dashboards**
- [x] Create a whitelist of the official dashboards:
  - Data Analysis: `data-analysis`
  - Media Management: `media-management`
  - Web Hosting: `web-hosting`
- [x] Display the whitelist after selecting the "+" on the tab that lists a project's dashboards

**Allow any dashboard to be shared**
- [x] Selecting the share icon on a dashboard will open a dialog which gives the user a unique ID like those above. If there's a conflict, append `-Date.now()` after the slug
- [x] Design an "Import" tab in the "Create Dashboard" dialog that accepts a dashboard ID (from the above step). It will:
  - Display the name of the plugin (allow it to be changed)
  - The names of the plug-ins it uses
- [ ] Filter out private data before publishing

**Support configuring a dashboard**
- [ ] editing its name
- [x] deleting it
- [ ] un-doing the delete

**Odds and ends**
- [ ] Redirect `/projects/{projectId}/` to homepage view with the project's tab selected
